### PR TITLE
add `make run_polling`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ build:
 run:
 	bundle exec middleman server
 
+.PHONY: run_polling
+run_polling:
+	bundle exec middleman server --watcher-force-polling
+
 .PHONY: deploy
 deploy: build
 	bundle exec middleman deploy


### PR DESCRIPTION
because livereload doesn't work when middleman is running inside a VM,
and your editor is outside.