### PR TITLE
fix broken build :\

### DIFF
--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -109,7 +109,7 @@ p, ul, ol {
     @include vertical-rhythm(1rem, 1, 0);
     font-family: 'Merriweather', sans-serif;
     em {
-      font-weight: 900;
+      font-style: italic;
     }
 }
 


### PR DESCRIPTION
From https://developer.mozilla.org/en-US/docs/Web/HTML/Element/em:
    
> The <em> element is for words that have a stressed emphasis compared
> to surrounding text, which is often limited to a word or words of a
> sentence and affects the meaning of the sentence itself.
>
> Typically this element is displayed in italic type.
