### PR TITLE
Only show latest blog post on blog/index

### DIFF
--- a/source/blog/index.html.md.erb
+++ b/source/blog/index.html.md.erb
@@ -5,8 +5,8 @@ blog: blog
 
 <% latest_post = blog.articles.first %>
 
+<p class="date"><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
 <h1 class="blog-title"><%= link_to "#{latest_post.title}", latest_post.url %></h1>
-<p><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
 <%= latest_post.body %>
 
 ---

--- a/source/blog/index.html.md.erb
+++ b/source/blog/index.html.md.erb
@@ -3,9 +3,21 @@ layout: singlepage
 blog: blog
 ---
 
+<% latest_post = blog.articles.first %>
+
+<h1 class="blog-title"><%= link_to "#{latest_post.title}", latest_post.url %></h1>
+<p><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
+<%= latest_post.body %>
+
+---
+
+<h2><a name="previous"></a> All blog posts:</h2>
+
+<ul>
 <% blog.articles.each do |article| %>
-  <h1 class="blog-title"><%= link_to "#{article.title}", article.url %></h1>
-  <p><%= article.date.strftime('%A') %> <%= article.date.day.ordinalize %> <%= article.date.strftime('%b %Y') %></p>
-  <%= article.body %>
-  <br />
+  <li class="blog-index">
+    <%= link_to "#{article.title}", article.url %>
+    <%= article.date.strftime('%A') %> <%= article.date.day.ordinalize %> <%= article.date.strftime('%b %Y') %>
+  </li>
 <% end %>
+</ul>

--- a/source/blog/index.html.md.erb
+++ b/source/blog/index.html.md.erb
@@ -6,7 +6,7 @@ blog: blog
 <% latest_post = blog.articles.first %>
 
 <p class="date"><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
-<h1 class="blog-title"><%= link_to "#{latest_post.title}", latest_post.url %></h1>
+<h1><%= link_to "#{latest_post.title}", latest_post.url %></h1>
 <%= latest_post.body %>
 
 ---

--- a/source/layouts/blog-post.erb
+++ b/source/layouts/blog-post.erb
@@ -1,5 +1,5 @@
 <% wrap_layout :singlepage do %>
-    <p class="date"><%= current_article.date.strftime('%d %B %Y') %></p>
+    <p class="date"><%= current_article.date.strftime('%A') %> <%= current_article.date.day.ordinalize %> <%= current_article.date.strftime('%b %Y') %></p>
     <h1><%= current_page.title %></h1>
     <%= yield %>
     <hr />

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -435,12 +435,6 @@ div.full-width {
     }
     h1 {
       @include vertical-rhythm(1.7rem, 0.5, 0.5);
-      &.blog-title {
-        border-bottom: 1px solid $button-primary;
-        a {
-          text-decoration: none;
-        }
-      }
     }
     h2 {
       @include vertical-rhythm(1.4rem, 0.5, 1.5);


### PR DESCRIPTION
We now show a list of all posts at the bottom of this page.

This also meant removing the custom blog h1. Originally, I introduced this
style to create a visual 'break' between each post on the home page (when we
were displaying more than one post). Since now you can only view one post per
page, this is redundant.

I've also taken this opportunity to present dates consistenly across blog.