### PR TITLE
Remove preceeding whitespace in `pre` blocks

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -16,7 +16,7 @@ layout: singlepage
             <pre>echo 'deb [arch=amd64] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list</pre>
             <p>3. Install:</p>
             <pre>sudo apt update
-    sudo apt install fluidkeys</pre>
+sudo apt install fluidkeys</pre>
         </div>
         <div class="operating-system" id="mac">
             <div class="logos">
@@ -25,8 +25,8 @@ layout: singlepage
             <h2>macOS</h2>
             <p>You can use <a href="https://brew.sh/">Homebrew</a> to install Fluidkeys:</p>
             <pre>brew tap fluidkeys/tap
-    brew update
-    brew install fluidkeys</pre>
+brew update
+brew install fluidkeys</pre>
         </div>
         <div class="operating-system" id="source">
             <h2>Source install</h2>


### PR DESCRIPTION
I thought about implementing `pre-line` on `pre`, but since this
collapses *all* white space, it'd prove problematic for displaying
data like we might want from a terminal, like:

```
Name         Age
-----------  ----
Jane         53
Jonathan     14
```

Therefore, I opted to simply pull the whitespace out of our `pre` blocks.