### PR TITLE
Fix broken links in week 12 weeknotes

### DIFF
--- a/source/weeknotes/2018-10-26-week-12.html.md
+++ b/source/weeknotes/2018-10-26-week-12.html.md
@@ -63,9 +63,9 @@ Key discovery means finding a public key from an email address.
 
 Autocrypt achieves this by embedding keys in the header of outgoing emails.
 
-Additional discovery mechanisms are emerging. [Web Key Discovery (WKD)](https://tools.ietf.org/html/draft-koch-openpgp-webkey-service-06) uses the `/.well-known/openpgpkey` directory over HTTPS. If a client has an email address, they map it to a specific URL, and request that URL for a key.
+Additional discovery mechanisms are emerging. [Web Key Directory (WKD)](https://tools.ietf.org/html/draft-koch-openpgp-webkey-service-06) uses the `/.well-known/openpgpkey` directory over HTTPS. If a client has an email address, they map it to a specific URL, and request that URL for a key.
 
-We [implemented this today](https://github.com/fluidkeys/web-key-discovery) using a Github repository as the backend.
+We [implemented this today](https://github.com/fluidkeys/web-key-directory) using a Github repository as the backend.
 
 WKD has some issues and the documentation is challenging, but it's a great concept. We sent out our release note with a `reply-to` header pointing to `hello@fluidkeys.com`. Any WKD-enabled mail client will automatically find the key and use it to encrypt to us.
 

--- a/source/weeknotes/2018-10-26-week-12.html.md
+++ b/source/weeknotes/2018-10-26-week-12.html.md
@@ -79,7 +79,7 @@ It used to feel like OpenPGP meant GnuPG. That meant applications bundling a bin
 
 There's still plenty of that, but some decent first-class implementations have emerged too:
 
-* [OpenPGP.js](#)
+* [OpenPGP.js](https://openpgpjs.org/)
 * [Sequoia](https://sequoia-pgp.org/), a new Rust implemtation
 * [golang/crypto](https://github.com/golang/crypto/) (ProtonMail maintain a [significant fork](https://github.com/protonmail/crypto))
 


### PR DESCRIPTION
* Web Key Discovery -> Directory
* add missing link to https://openpgpjs.org/