### PR TITLE
tweak download page

### DIFF
--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -9,7 +9,7 @@ layout: singlepage
                 <%= image_tag 'logos/debian-logo.svg', alt: "Debian logo", class: "logo" %>
                 <%= image_tag 'logos/ubuntu-logo.svg', alt: "Debian logo", class: "logo" %>
             </div>
-            <h2>Debian / Ubuntu</h2>
+            <h2>Install on Debian / Ubuntu</h2>
             <p>1. Get our public key:</p>
             <pre>curl --silent https://www.fluidkeys.com/release.asc | sudo apt-key add -</pre>
             <p>2. Add our apt repository:</p>
@@ -22,7 +22,7 @@ sudo apt install fluidkeys</pre>
             <div class="logos">
                 <%= image_tag 'logos/apple-logo.svg', alt: "Apple logo", class: "logo" %>
             </div>
-            <h2>macOS</h2>
+            <h2>Install on macOS</h2>
             <p>You can use <a href="https://brew.sh/">Homebrew</a> to install Fluidkeys:</p>
             <pre>brew tap fluidkeys/tap
 brew update

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -29,8 +29,20 @@ brew install fluidkeys</pre>
             <p>Requires <a href="https://brew.sh/">Homebrew.</a></p>
         </div>
         <div class="operating-system" id="source">
-            <h2>Source install</h2>
-            <p><a href="https://github.com/fluidkeys/fluidkeys/blob/master/README.md#install-from-source">Install from source</a></p>
+            <h2>Install from source</h2>
+            <p>1. Install the <a href="https://golang.org/dl/#featured">Go compiler</a></p>
+
+            <p>2. Clone our repository:</p>
+            <pre>export REPO=$(go env GOPATH)/src/github.com/fluidkeys/fluidkeys
+
+git clone https://github.com/fluidkeys/fluidkeys.git $REPO
+cd $REPO</pre>
+
+            <p>3.a) Build and install to <code>/usr/local/bin/fk</code>
+            <pre>make && sudo make install</pre>
+
+            <p>3.b) Or without <code>sudo</code> (root):</p>
+            <pre>PREFIX=$HOME make && make install</pre>
         </div>
     </div>
 </div>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -10,7 +10,7 @@ layout: singlepage
                 <%= image_tag 'logos/ubuntu-logo.svg', alt: "Debian logo", class: "logo" %>
             </div>
             <h2>Install on Debian / Ubuntu</h2>
-            <p>1. Get our public key:</p>
+            <p>1. Get our signing key:</p>
             <pre>curl --silent https://www.fluidkeys.com/release.asc | sudo apt-key add -</pre>
             <p>2. Add our apt repository:</p>
             <pre>echo 'deb [arch=amd64] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list</pre>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -24,7 +24,6 @@ sudo apt install fluidkeys</pre>
             </div>
             <h2>Install on macOS</h2>
             <pre>brew tap fluidkeys/tap
-brew update
 brew install fluidkeys</pre>
 
             <p>Requires <a href="https://brew.sh/">Homebrew.</a></p>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -2,7 +2,7 @@
 layout: singlepage
 ---
 <div class="download">
-    <h1>Download Fluidkeys</h1>
+    <h1>Install Fluidkeys</h1>
     <div class="systems">
         <div class="operating-system" id="debian-ubuntu">
             <div class="logos">

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -23,10 +23,11 @@ sudo apt install fluidkeys</pre>
                 <%= image_tag 'logos/apple-logo.svg', alt: "Apple logo", class: "logo" %>
             </div>
             <h2>Install on macOS</h2>
-            <p>You can use <a href="https://brew.sh/">Homebrew</a> to install Fluidkeys:</p>
             <pre>brew tap fluidkeys/tap
 brew update
 brew install fluidkeys</pre>
+
+            <p>Requires <a href="https://brew.sh/">Homebrew.</a></p>
         </div>
         <div class="operating-system" id="source">
             <h2>Source install</h2>

--- a/source/download.html.erb
+++ b/source/download.html.erb
@@ -11,7 +11,7 @@ layout: singlepage
             </div>
             <h2>Install on Debian / Ubuntu</h2>
             <p>1. Get our signing key:</p>
-            <pre>curl --silent https://www.fluidkeys.com/release.asc | sudo apt-key add -</pre>
+            <pre>curl https://www.fluidkeys.com/release.asc | sudo apt-key add -</pre>
             <p>2. Add our apt repository:</p>
             <pre>echo 'deb [arch=amd64] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list</pre>
             <p>3. Install:</p>


### PR DESCRIPTION
* Add "Install from source" instructions

* drop --silent from curl
  it prevents the line from overflowing, and it only marginally affects the
  experience.

* "Get our public key" -> "Get our signing key"

* drop unnecessary `brew update` step

* Move "You can use Homebrew" below <pre>
  and reword to "Requires Homebrew". It's not the headline.

* h2: "macOS" -> "Install on macOS" (+ ubuntu)

* h1: "Download Fluidkeys" -> "Install Fluidkeys"