### PR TITLE
upversion `nokogiri` (type `bundle` to update)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,4 +10,4 @@ gem 'middleman-gh-pages'
 gem 'redcarpet'
 gem 'tzinfo-data', platforms: [:mswin, :mingw, :jruby]
 gem 'wdm', '~> 0.1', platforms: [:mswin, :mingw]
-gem 'nokogiri'
+gem "nokogiri", ">= 1.8.5"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,13 +93,13 @@ GEM
       em-websocket (~> 0.5.1)
       middleman-core (>= 3.3)
       rack-livereload (~> 0.3.15)
-    mini_portile2 (2.3.0)
+    mini_portile2 (2.4.0)
     minitest (5.10.3)
     net-sftp (2.1.2)
       net-ssh (>= 2.6.5)
     net-ssh (4.1.0)
-    nokogiri (1.8.4)
-      mini_portile2 (~> 2.3.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.4)
@@ -139,7 +139,7 @@ DEPENDENCIES
   middleman-deploy (~> 2.0.0.pre.alpha)
   middleman-gh-pages
   middleman-livereload (~> 3.4.3)
-  nokogiri
+  nokogiri (>= 1.8.5)
   redcarpet
   tzinfo-data
   wdm (~> 0.1)


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2018-14404