### PR TITLE
Put signup form above previous weeknotes

### DIFF
--- a/source/weeknotes/index.html.md.erb
+++ b/source/weeknotes/index.html.md.erb
@@ -11,6 +11,10 @@ description: Keep up to date with our progress building Fluidkeys, a way to prot
 
 ---
 
+## Sign up to get emailed them each week:
+
+<%= partial "weeknotes/signup_form"  %>
+
 ## <a name="previous"></a> Previous weeknotes:
 
 <ul>
@@ -21,9 +25,3 @@ description: Keep up to date with our progress building Fluidkeys, a way to prot
   </li>
 <% end %>
 </ul>
-
----
-
-## Sign up to get emailed them each week:
-
-<%= partial "weeknotes/signup_form"  %>


### PR DESCRIPTION
Haven't quite got the format correct yet, but the idea is that the
signup form gets kind of lost now we've got lots of weeknotes.