### PR TITLE
point release notes to new mailchimp list & use kiffix as our example company

### DIFF
--- a/source/_signup_form.html.erb
+++ b/source/_signup_form.html.erb
@@ -1,7 +1,7 @@
 <form id="<%= form_id %>" action="https://fluidkeys.us20.list-manage.com/subscribe/post?u=fd279ba68240c3d0639990f7e&amp;id=eb0e518b12" method="post">
   <div>
     <label for="email-address">Email address:</label>
-    <input id="email-address" type="email" name="EMAIL" required placeholder="e.g. sandra@flextech.com">
+    <input id="email-address" type="email" name="EMAIL" required placeholder="e.g. brian@kiffix.com">
   </div>
   <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fd279ba68240c3d0639990f7e_69b83e3491" tabindex="-1" value=""></div>
   <div>

--- a/source/_signup_form.html.erb
+++ b/source/_signup_form.html.erb
@@ -1,4 +1,4 @@
-<form id="<%= form_id %>" action="https://fluidkeys.us20.list-manage.com/subscribe/post?u=fd279ba68240c3d0639990f7e&amp;id=69b83e3491" method="post">
+<form id="<%= form_id %>" action="https://fluidkeys.us20.list-manage.com/subscribe/post?u=fd279ba68240c3d0639990f7e&amp;id=eb0e518b12" method="post">
   <div>
     <label for="email-address">Email address:</label>
     <input id="email-address" type="email" name="EMAIL" required placeholder="e.g. sandra@flextech.com">

--- a/source/weeknotes/_signup_form.html.erb
+++ b/source/weeknotes/_signup_form.html.erb
@@ -1,7 +1,7 @@
 <form class="inline-button" action="https://fluidkeys.us20.list-manage.com/subscribe/post?u=fd279ba68240c3d0639990f7e&amp;id=fc096a3913" method="post">
   <div class="input">
     <label for="email-address">Email address:</label>
-    <input id="email-address" type="email" name="EMAIL" required placeholder="">
+    <input id="email-address" type="email" name="EMAIL" required placeholder="e.g. cienna@kiffix.com">
   </div>
   <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_fd279ba68240c3d0639990f7e_fc096a3913" tabindex="-1" value=""></div>
   <div class="button">


### PR DESCRIPTION
Mailchimp doesn't allow you to delete a subscriber and then re-add them.
This caused a lot of pain, since I wanted to get the correct time-stamp for
their opt-in confirmation linked to emails, and got it wrong the first time
around.