### PR TITLE
renaming this class 'markdown' is more representative

### DIFF
--- a/source/blog/index.html.md.erb
+++ b/source/blog/index.html.md.erb
@@ -5,7 +5,7 @@ blog: blog
 
 <% latest_post = blog.articles.first %>
 
-<p class="weeknote__date"><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
+<p class="markdown__date"><%= latest_post.date.strftime('%A') %> <%= latest_post.date.day.ordinalize %> <%= latest_post.date.strftime('%b %Y') %></p>
 <h1><%= link_to "#{latest_post.title}", latest_post.url %></h1>
 <%= latest_post.body %>
 

--- a/source/layouts/blog-post.erb
+++ b/source/layouts/blog-post.erb
@@ -1,5 +1,5 @@
 <% wrap_layout :singlepage do %>
-    <p class="date"><%= current_article.date.strftime('%A') %> <%= current_article.date.day.ordinalize %> <%= current_article.date.strftime('%b %Y') %></p>
+    <p class="markdown__date"><%= current_article.date.strftime('%A') %> <%= current_article.date.day.ordinalize %> <%= current_article.date.strftime('%b %Y') %></p>
     <h1><%= current_page.title %></h1>
     <%= yield %>
     <hr />

--- a/source/layouts/singlepage.erb
+++ b/source/layouts/singlepage.erb
@@ -1,6 +1,6 @@
 <% wrap_layout :layout do %>
     <section class="container--max-width-break-2">
-        <div class="weeknote">
+        <div class="markdown">
             <%= yield %>
         </div>
     </section>

--- a/source/layouts/weeknote.erb
+++ b/source/layouts/weeknote.erb
@@ -1,5 +1,5 @@
 <% wrap_layout :singlepage do %>
-    <p class="weeknote__date"><%= current_article.date.strftime('%d %B %Y') %></p>
+    <p class="markdown__date"><%= current_article.date.strftime('%d %B %Y') %></p>
     <h1><%= current_page.title %></h1>
     <%= yield %>
     <hr />

--- a/source/stylesheets/blocks/_markdown.scss
+++ b/source/stylesheets/blocks/_markdown.scss
@@ -1,4 +1,4 @@
-.weeknote {
+.markdown {
     margin-top: #{$line-height-base};
     margin-bottom: #{$line-height-base};
 

--- a/source/stylesheets/site.css.scss
+++ b/source/stylesheets/site.css.scss
@@ -20,10 +20,11 @@
 @import 'blocks/header';
 @import 'blocks/highlight-band';
 @import 'blocks/landing-hero';
+@import 'blocks/markdown';
 @import 'blocks/menu';
 @import 'blocks/nav';
 @import 'blocks/pgp-app';
 @import 'blocks/preview-announcement';
 @import 'blocks/section';
 @import 'blocks/terminal';
-@import 'blocks/weeknote';
+

--- a/source/weeknotes/index.html.md.erb
+++ b/source/weeknotes/index.html.md.erb
@@ -5,7 +5,7 @@ blog: weeknotes
 description: Keep up to date with our progress building Fluidkeys, a way to protect your team with strong encryption.
 ---
 
-<p class="weeknote__date"><%= blog.articles.first.date.strftime('%d %B %Y') %></p>
+<p class="markdown__date"><%= blog.articles.first.date.strftime('%d %B %Y') %></p>
 <h1><%= link_to blog.articles.first.title, blog.articles.first.url %></h1>
 <%= blog.articles.first.body %>
 
@@ -19,7 +19,7 @@ description: Keep up to date with our progress building Fluidkeys, a way to prot
 
 <ul>
 <% blog.articles[1..-1].each do |article| %>
-  <li class="weeknote__index-item">
+  <li class="markdown__index-item">
     <%= link_to "#{article.title}", article.url %>
     <%= article.date.strftime('%A') %> <%= article.date.day.ordinalize %> <%= article.date.strftime('%b %Y') %>
   </li>


### PR DESCRIPTION
We use to wrap markdown content, and it styles the markdown
elements appropriately.