### PR TITLE
nav: link to /download not download.fluidkeys.com

### DIFF
--- a/hugo/layouts/_default/baseof.html
+++ b/hugo/layouts/_default/baseof.html
@@ -52,7 +52,7 @@
               <li class="nav__item"><a href="/blog" class="nav__link">Blog</a></li>
               <li class="nav__item"><a href="/weeknotes" class="nav__link">Weeknotes</a></li>
               <li class="nav__item"><a href="/about" class="nav__link">About</a></li>
-              <li class="nav__item"><a href="https://download.fluidkeys.com" class="nav__link">Download</a></li>
+              <li class="nav__item"><a href="/download" class="nav__link">Download</a></li>
             </ul>
           </nav>
         </div>


### PR DESCRIPTION
download.fluidkeys.com actually just redirects back to
fluidkeys.com/download, so link directly to /download