### PR TITLE
disable taxonomies (categories and tags)

### DIFF
--- a/hugo/config.toml
+++ b/hugo/config.toml
@@ -1,3 +1,4 @@
 baseURL = "https://www.fluidkeys.com/"
 languageCode = "en-gb"
 title = "Fluidkeys"
+disableKinds = ["taxonomy","taxonomyTerm"]


### PR DESCRIPTION
Hugo was throwing warnings that it couldn't find the layouts for
them.