### PR TITLE
Improve the CSS for markdown in prepartion for docs

### DIFF
--- a/hugo/assets/sass/blocks/_markdown.scss
+++ b/hugo/assets/sass/blocks/_markdown.scss
@@ -116,5 +116,9 @@
         border: 1px solid $color-markdown-callout--info--border;
     }
 
-
+    pre {
+        code {
+            box-shadow: none;
+        }
+    }
 }

--- a/hugo/assets/sass/blocks/_markdown.scss
+++ b/hugo/assets/sass/blocks/_markdown.scss
@@ -39,7 +39,7 @@
         }
     }
     hr {
-        margin-bottom: #{2 * $line-height-base};
+        border: 1px solid $color-grey--mid;
     }
     img {
         max-width: 100%;

--- a/hugo/assets/sass/blocks/_markdown.scss
+++ b/hugo/assets/sass/blocks/_markdown.scss
@@ -79,4 +79,42 @@
         padding-top: #{0.5 * $line-height-base};
         padding-bottom: #{0.5 * $line-height-base};
     }
+
+    .callout {
+        &:before {
+            content: "";
+            position: absolute;
+            top: #{0.7 * $line-height-base};
+            left: #{0.5 * $line-height-base};
+            @include vertical-rhythm(1.5rem, 0.5, 0);
+        }
+        position: relative;
+        padding-top: #{0.5 * $line-height-base};
+        padding-bottom: #{0.5 * $line-height-base};
+        padding-left: $line-height-base * 1.8;
+        padding-right: #{0.5 * $line-height-base};
+        margin-bottom: $line-height-base;
+        @include border-radius(5px);
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    .callout--warning {
+        &:before {
+            content: "⚠️";
+        }
+        background: $color-markdown-callout--warning--background;
+        border: 1px solid $color-markdown-callout--warning--border;
+    }
+
+    .callout--info {
+        &:before {
+            content: "ℹ️";
+        }
+        background: $color-markdown-callout--info--background;
+        border: 1px solid $color-markdown-callout--info--border;
+    }
+
+
 }

--- a/hugo/assets/sass/blocks/_markdown.scss
+++ b/hugo/assets/sass/blocks/_markdown.scss
@@ -1,16 +1,42 @@
 .markdown {
+    counter-reset: heading;
     margin-top: #{$line-height-base};
     margin-bottom: #{$line-height-base};
+
+    .numbered {
+        @include breakpoint(break-3) {
+            position: relative;
+            &:before {
+                position: absolute;
+                top: 0;
+                left: -3rem;
+                width: 2rem;
+                text-align: right;
+            }
+        }
+
+    }
 
     h1 {
         @include vertical-rhythm(1.7rem, 0.5, 0.5);
     }
     h2 {
         @include vertical-rhythm(1.4rem, 0.5, 1.5);
+        &.numbered {
+            counter-reset: subheading;
+            &:before {
+                content: counter(heading)". ";
+                counter-increment: heading;
+            }
+        }
     }
     h3 {
         font-family: 'Merriweather', sans-serif;
         font-weight: bold;
+        &.numbered:before {
+            content: counter(heading)"."counter(subheading)". ";
+            counter-increment: subheading;
+        }
     }
     hr {
         margin-bottom: #{2 * $line-height-base};

--- a/hugo/assets/sass/blocks/_terminal.scss
+++ b/hugo/assets/sass/blocks/_terminal.scss
@@ -1,5 +1,6 @@
 $terminal-background: #202020;
 $terminal-foreground: #EAEAEA;
+$terminal-output: #bebec5;
 $terminal-disabled: #7C7C7C;
 $terminal-light-green: #8BC34B;
 $terminal-light-blue: #65B5F6;
@@ -8,19 +9,22 @@ $terminal-red: #C72828;
 $terminal-light-red: #F05350;
 
 pre.terminal {
+  border: 0;
   font-family: 'Inconsolata', monospace;
-  white-space: pre-wrap;
   text-align: justify;
   display: block;
-  word-break: break-word;
   background: $terminal-background;
   color: $terminal-foreground;
   @include vertical-rhythm(1em, 0, 0);
   line-height: #{$line-height-base * 0.65};
-  padding: $line-height-base;
+  padding: #{$line-height-base * 0.5};
   @include border-radius(#{$line-height-base * 0.25});
   .prompt {
     color: $terminal-light-green;
+  }
+  .command:before {
+    color: $terminal-light-green;
+    content: "> ";
   }
   .cursor {
     color: $terminal-light-blue;
@@ -52,6 +56,11 @@ pre.terminal {
   .header {
     background: $terminal-light-blue;
     color: $terminal-background;
+    width: 100%;
+    display: inline-block;
+  }
+  .output {
+    color: $terminal-output;
   }
   margin-bottom: $line-height-base;
 }

--- a/hugo/assets/sass/variables/_colors.scss
+++ b/hugo/assets/sass/variables/_colors.scss
@@ -7,7 +7,11 @@ $color-grey--dark: #232732;
 $color-pink: #d33d5c;
 $color-green: #3DA450;
 $color-green--light: #00BB3D;
+$color-yellow--dark: rgb(190, 174, 78);
 $color-yellow--light: #FFF4B3;
+$color-yellow--extra-light: rgb(255, 250, 219);
+$color-blue--dark: rgba(0,107,212,0.2);
+$color-blue--extra-light: rgba(0,107,212,0.1);
 
 // Functional colors
 $color-html--background: $color-white;
@@ -74,3 +78,8 @@ $color-pre--border: $color-grey--mid;
 
 $color-highlight-band--background: $color-pink;
 $color-highlight-band__subtitle-color: $color-white;
+
+$color-markdown-callout--warning--background: $color-yellow--extra-light;
+$color-markdown-callout--warning--border: $color-yellow--dark;
+$color-markdown-callout--info--background: $color-blue--extra-light;
+$color-markdown-callout--info--border: $color-blue--dark;

--- a/hugo/assets/sass/variables/_colors.scss
+++ b/hugo/assets/sass/variables/_colors.scss
@@ -1,7 +1,7 @@
 // Descriptive colors
 $color-white: #ffffff;
 $color-grey: #8c8c8c;
-$color-grey--light: #efefef;
+$color-grey--light: #f5f5f7;
 $color-grey--mid: #cccccc;
 $color-grey--dark: #232732;
 $color-pink: #d33d5c;
@@ -74,6 +74,7 @@ $color-nav__link: $color-white;
 $color-nav__link-hover: $color-pink;
 
 $color-pre--background: $color-grey--light;
+$color-pre: $color-grey--dark;
 $color-pre--border: $color-grey--mid;
 
 $color-highlight-band--background: $color-pink;

--- a/hugo/assets/sass/variables/_typography.scss
+++ b/hugo/assets/sass/variables/_typography.scss
@@ -59,6 +59,8 @@ code {
     @include border-radius(3px);
     padding-left: 5px;
     padding-right: 5px;
+    box-shadow: inset 0 0 0 1px rgba(0,0,0,0.1);
+    color: $color-pre;
 }
 
 pre {
@@ -68,11 +70,6 @@ pre {
     padding: 0.5rem;
     @include vertical-rhythm(1rem, 1, 1);
     @include border-radius(3px);
-    white-space: pre-wrap;       /* css-3 */
-    white-space: -moz-pre-wrap;  /* Mozilla, since 1999 */
-    white-space: -pre-wrap;      /* Opera 4-6 */
-    white-space: -o-pre-wrap;    /* Opera 7 */
-    word-wrap: break-word;
 }
 
 a {


### PR DESCRIPTION
* lighten the hr element
* add 'output' class for terminal (make it a light grey)
* add 'command' class for terminal (prefix it with a green prompt)
* stop wrapping the content in 'pre' blocks
* lighten the grey background on 'pre' blocks
* add slight shadow to inline 'code' snippets
* add 'callout' for 'warning' and 'info' (contents of the div's must then be in HTML)
* add numbers to h2 and h3s with .numbered class (This formats the numbers such that on a desktop they are pulled left into the margin so the headers align nicely.)