### PR TITLE
tweaks to fluidkeys / gpg docs

### DIFF
--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -15,7 +15,8 @@ Contents:
 1. [Prerequisites](#prerequisites)
 2. [Import your PGP key into Fluidkeys](#import-key)
 3. [Upload your public key to the keyservers](#upload-to-keyservers)
-4. [Remind your contacts to refresh their keys](#remind-contacts)
+4. [Upload your public key to Fluidkeys](#upload-to-fluidkeys)
+5. [Remind your contacts to refresh their keys](#remind-contacts)
 
 <h2 class="numbered" id="prerequisites">Prerequisites</h2>
 

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -13,7 +13,7 @@ You can use it to automatically maintain a key you've already made using GnuPG, 
 Contents:
 
 1. [Prerequisites](#prerequisites)
-2. [Import your PGP key into Fluidkeys](#import-key)
+2. [Connect Fluidkeys to your key in GnuPG](#connect-key)
 3. [Upload your public key to the keyservers](#upload-to-keyservers)
 4. [Upload your public key to Fluidkeys](#upload-to-fluidkeys)
 5. [Remind your contacts to refresh their keys](#remind-contacts)
@@ -25,7 +25,7 @@ You'll need:
 * [Fluidkeys](https://download.fluidkeys.com) &ge; 1.0
 * An existing PGP key stored in [GnuPG](https://www.gnupg.org/)
 
-<h2 class="numbered" id="import-key">Import your PGP key into Fluidkeys</h2>
+<h2 class="numbered" id="connect-key">Connect Fluidkeys to your key in GnuPG</h2>
 
 Import your existing key stored in GnuPG to Fluidkeys by running `fk key from-gpg`.
 

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -74,7 +74,7 @@ Remember to upload your updated key to the keyservers:
 Fluidkeys automatically extends your key every month.
 
 To ensure your key is always up to date in the keyservers, you should use `cron` to automatically
-push the key.
+upload the key.
 
 Edit your crontab file:
 
@@ -90,7 +90,7 @@ then add the following line:
 
 <h2 class="numbered" id="upload-to-fluidkeys">Upload your public key to Fluidkeys</h2>
 
-If you'd like to receive secrets using Fluidkeys, you should also push your key to the Fluidkeys server:
+If you'd like to receive secrets using Fluidkeys, you should also upload your key to the Fluidkeys server:
 
 <pre class="terminal">
 <span class="command">fk key upload</span>

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -62,7 +62,7 @@ Given that you're key will be modified each month now, you should now setup a `c
 
 To do that, edit your cron file run by running `crontab -e` and add the following line:
 
-<pre class="terminal">
+<pre>
 0 0 1 * * gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 'A999 B749 8D1A 8DC4 73E5 3C92 309F 635D AD1B 5517'
 </pre>
 

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -55,15 +55,17 @@ Fluidkeys will also have updated your cipher, hash and compression preferences t
 Remember to upload your updated key to the keyservers:
 
 <pre class="terminal">
-<span class="command">gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 'A999 B749 8D1A 8DC4 73E5 3C92 309F 635D AD1B 5517'
+<span class="command">gpg --keyserver hkps://hkps.pool.sks-keyservers.net --send-keys 'KEY-FINGERPRINT'
 </pre>
 
-Given that you're key will be modified each month now, you should now setup a `cron` task to run this command on the 1st of each month.
+<div class="callout callout--info"><p>Replace <code>KEY-FINGERPRINT</code> with your fingerprint, for example <code>A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517</code>. Make sure it's between quote marks.</p></div>
+
+Given that your key will be modified each month now, you should now setup a `cron` task to run this command on the 1st of each month.
 
 To do that, edit your cron file run by running `crontab -e` and add the following line:
 
 <pre>
-0 0 1 * * gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 'A999 B749 8D1A 8DC4 73E5 3C92 309F 635D AD1B 5517'
+@daily gpg --keyserver hkps://hkps.pool.sks-keyservers.net --send-keys 'KEY-FINGERPRINT'
 </pre>
 
 <h2 class="numbered" id="upload-to-fluidkeys">Upload your public key to Fluidkeys</h2>

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -27,7 +27,11 @@ You'll need:
 
 <h2 class="numbered" id="connect-key">Connect Fluidkeys to your key in GnuPG</h2>
 
-Import your existing key stored in GnuPG to Fluidkeys by running `fk key from-gpg`.
+Allow Fluidkeys to access your key in GnuPG:
+
+<pre class="terminal">
+<span class="command">fk key from-gpg</span>
+</pre>
 
 When asked to "Connect this key?" type `Y` to say yes. (If you've more than one key in GPG, you
 can select which you'd like to manage with Fluidkeys).
@@ -39,7 +43,11 @@ like this:
  <span class="notice">▸</span>   <span class="error">Primary key needs extending now (expires in 2 days)</span>
 </pre>
 
-To fix this and any other errors, run `fk key maintain`.
+To extend your key and fix any other issues, run:
+
+<pre class="terminal">
+<span class="command">fk key maintain</span>
+</pre>
 
 You'll be asked three questions, answer `Y` for each:
 

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -26,7 +26,7 @@ You'll need:
 
 <h2 class="numbered" id="import-key">Import your PGP key into Fluidkeys</h2>
 
-Import your existing key stored in GnuPGP to Fluidkeys by running `fk key from-gpg`.
+Import your existing key stored in GnuPG to Fluidkeys by running `fk key from-gpg`.
 
 When asked to "Connect this key?" type `Y` to say yes. (If you've more than one key in GPG, you
 can select which you'd like to manage with Fluidkeys).

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -14,7 +14,7 @@ Contents:
 
 1. [Prerequisites](#prerequisites)
 2. [Import your PGP key into Fluidkeys](#import-key)
-3. [Push it to the keyservers](#push-to-keyservers)
+3. [Upload your public key to the keyservers](#upload-to-keyservers)
 4. [Remind your contacts to refresh their keys](#remind-contacts)
 
 <h2 class="numbered" id="prerequisites">Prerequisites</h2>
@@ -49,9 +49,9 @@ You'll be asked three questions, answer `Y` for each:
 Once complete, your key will have a new expiry date set to at the end of next month.
 Fluidkeys will also have updated your cipher, hash and compression preferences to best practice recommendations.
 
-<h2 class="numbered" id="push-to-keyservers">Push it to the keyservers</h2>
+<h2 class="numbered" id="upload-to-keyservers">Upload your public key to the keyservers</h2>
 
-Remember to push your updated key to the keyservers:
+Remember to upload your updated key to the keyservers:
 
 <pre class="terminal">
 <span class="command">gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 'A999 B749 8D1A 8DC4 73E5 3C92 309F 635D AD1B 5517'
@@ -65,7 +65,7 @@ To do that, edit your cron file run by running `crontab -e` and add the followin
 0 0 1 * * gpg --keyserver hkp://pool.sks-keyservers.net --send-keys 'A999 B749 8D1A 8DC4 73E5 3C92 309F 635D AD1B 5517'
 </pre>
 
-<h2 class="numbered" id="push-to-keyservers">Push it to Fluidkeys server</h2>
+<h2 class="numbered" id="upload-to-fluidkeys">Upload your public key to Fluidkeys</h2>
 
 If you'd like to receive secrets using Fluidkeys, you should also push your key to the Fluidkeys server:
 

--- a/hugo/content/docs/extend-your-key-from-gpg.md
+++ b/hugo/content/docs/extend-your-key-from-gpg.md
@@ -15,8 +15,9 @@ Contents:
 1. [Prerequisites](#prerequisites)
 2. [Connect Fluidkeys to your key in GnuPG](#connect-key)
 3. [Upload your public key to the keyservers](#upload-to-keyservers)
-4. [Upload your public key to Fluidkeys](#upload-to-fluidkeys)
-5. [Remind your contacts to refresh their keys](#remind-contacts)
+4. [Optional: automatically upload to the keyservers using cron](#upload-from-cron)
+5. [Upload your public key to Fluidkeys](#upload-to-fluidkeys)
+6. [Remind your contacts to refresh their keys](#remind-contacts)
 
 <h2 class="numbered" id="prerequisites">Prerequisites</h2>
 
@@ -68,9 +69,20 @@ Remember to upload your updated key to the keyservers:
 
 <div class="callout callout--info"><p>Replace <code>KEY-FINGERPRINT</code> with your fingerprint, for example <code>A999 B749 8D1A 8DC4 73E5  3C92 309F 635D AD1B 5517</code>. Make sure it's between quote marks.</p></div>
 
-Given that your key will be modified each month now, you should now setup a `cron` task to run this command on the 1st of each month.
+<h2 class="numbered" id="upload-from-cron">Optional: automatically upload to the keyservers using cron</h2>
 
-To do that, edit your cron file run by running `crontab -e` and add the following line:
+Fluidkeys automatically extends your key every month.
+
+To ensure your key is always up to date in the keyservers, you should use `cron` to automatically
+push the key.
+
+Edit your crontab file:
+
+<pre class="terminal">
+<span class="command">crontab -e
+</pre>
+
+then add the following line:
 
 <pre>
 @daily gpg --keyserver hkps://hkps.pool.sks-keyservers.net --send-keys 'KEY-FINGERPRINT'


### PR DESCRIPTION
* break crontab instructions into new section
* break out commands into their own <pre> blocks, rather than hiding them inline: it's much clearer
  what to do when we use the `<pre class="terminal">`
* improve crontab instructions
  - use KEY_FINGERPRINT instead of my actual fingerprint
  - add a callout reminding to replace `KEY-FINGERPRINT`
  - use hkps pool rather than hkp
  - use `@daily` as the previous crontab line was at midnight, when most people's machine is off..
* use ordinary `<pre>` for crontab
* "Import" -> "Connect": mirror the language we use in `fk`
* fix broken numbered list (missing section)
* "push" -> "upload"
* fix `GnuPGP`