### PR TITLE
Fix relative link for download instructions

### DIFF
--- a/hugo/content/docs/get-started.md
+++ b/hugo/content/docs/get-started.md
@@ -25,7 +25,7 @@ Contents:
 
 <h2  class="numbered">Prerequisites: Install Fluidkeys</h2>
 
-* [Fluidkeys installation instructions](www.fluidkeys.com/download)
+* [Fluidkeys installation instructions](https://www.fluidkeys.com/download)
 
 <h2 id="setup-team" class="numbered">Set up your team</h2>
 


### PR DESCRIPTION
Currently there is an unintended relative URL which points to an absolute target. It basically ends up with a dead link. By simply adding `https://` in front and making it an absolute link, this shouldn't happen anymore.