### PR TITLE
apt repo: narrow scope of cryptographic authority (avoid "apt-key add…

### DIFF
--- a/hugo/content/download.html
+++ b/hugo/content/download.html
@@ -11,9 +11,9 @@ title: "Download Fluidkeys"
             </div>
             <h2>Install on Debian / Ubuntu</h2>
             <p>1. Get our signing key:</p>
-            <pre>curl https://www.fluidkeys.com/release.asc | sudo apt-key add -</pre>
+            <pre>curl https://www.fluidkeys.com/release.asc | sudo gpg --dearmor --output /usr/share/keyrings/fluidkeys.gpg</pre>
             <p>2. Add our apt repository:</p>
-            <pre>echo 'deb [arch=amd64] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list</pre>
+            <pre>echo 'deb [arch=amd64 signed-by=/usr/share/keyrings/fluidkeys.gpg] https://download.fluidkeys.com/desktop/apt any main' | sudo tee /etc/apt/sources.list.d/fluidkeys.list</pre>
             <p>3. Install and run:</p>
             <pre>sudo apt update
 sudo apt install fluidkeys


### PR DESCRIPTION
… -")

For modern debian and debian-derived systems, you can specify which
OpenPGP certificates are specifically allowed for which repositories.

So currently, if someone with access to debian or ubuntu signing keys
(or copies of repositories signed by those keys) was able to write to
https://dlownload.fluidkeys.com/dekstop/apt/, they would be able to
inject installable packages on end-user systems, even though the
fluidkeys signing keys are still protected.

Additionally, piping the fluidkeys APT repo OpenPGP certificate into
"apt-key add -", indicates that the fluidkeys organization is
acceptable to certify *all* repos on the system.  You probably don't
want that responsibility.

This arrangement fine on debian stretch (apt 1.4.9), which is
currently "oldstable", but doesn't work on jessie (apt 1.0.9.8.4).  I
think that's a reasonable tradeoff in 2019.  I believe it was added in
apt 1.1, so it should work in ubuntu xenial and later, but i haven't
tested it on that platform.

See also: https://wiki.debian.org/DebianRepository/UseThirdParty